### PR TITLE
Added Serializable behavior to Shot class

### DIFF
--- a/src/ab/demo/other/Shot.java
+++ b/src/ab/demo/other/Shot.java
@@ -9,9 +9,14 @@
 package ab.demo.other;
 
 import java.awt.Point;
+import java.io.Serializable;
 
-public class Shot {
+public class Shot implements Serializable {
 
+	/**
+	 * 
+	 */
+	private static final long serialVersionUID = 2279112400720899118L;
 	private int x;
 	private int y;
 	private int dx;


### PR DESCRIPTION
Tinhamos um problema com a Classe Shot, por ela não ter implementado o Serializable.
Agora já temos isso e não vai dar mais erro com o `writeObject` :grin:
